### PR TITLE
Added link to ESPeasy

### DIFF
--- a/content/docs/instrumenting/exporters.md
+++ b/content/docs/instrumenting/exporters.md
@@ -65,6 +65,7 @@ wide variety of JVM-based applications, for example [Kafka](http://kafka.apache.
    * [Bosch Sensortec BMP/BME exporter](https://github.com/David-Igou/bsbmp-exporter)
    * [Collins exporter](https://github.com/soundcloud/collins_exporter)
    * [Dell Hardware OMSA exporter](https://github.com/galexrt/dellhw_exporter)
+   * [ESPEasy ESP32/8266 firmware builtin exporter](https://github.com/letscontrolit/ESPEasy)
    * [Disk usage exporter](https://github.com/dundee/disk_usage_exporter)
    * [Fortigate exporter](https://github.com/bluecmd/fortigate_exporter)
    * [IBM Z HMC exporter](https://github.com/zhmcclient/zhmc-prometheus-exporter)


### PR DESCRIPTION
As of the latest commit, ESPEasy has a prometheus exporter built in

<!--
    Please sign CNCF's Developer Certificate of Origin and sign-off your commits by adding the -s / --sign-off flag to `git commit`

    More information on both of those can be found at https://github.com/apps/dco

    If you are proposing a new integration, exporter, or client library, please include representative sample output.
 -->
